### PR TITLE
Added opener as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "husky": "^0.11.4",
     "jspm": "^0.17.0-beta.22",
     "jspm-hmr": "^0.4.1",
+    "opener": "^1.4.1",
     "regenerator": "^0.8.46",
     "typings": "^1.3.1"
   },


### PR DESCRIPTION
I didn't have 'opener' installed as a global module. This caused `npm start` to fail after following the installation instructions. I figured others might not have opener installed as well, so it seemed like a good idea to add it to devDependencies in package.json rather than require that opener be installed globally.

As a note about contributing, husky hooks appeared to be failing due to:

> tslint ./src/*_/_.ts\* 
> sh: tslint: command not found

Looking forward to trying the starter kit!
