### PR TITLE
Updating to systemjs-hot-reloader@1.1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,14 +33,14 @@
   <script src="jspm.config.js"></script>
   <script src="temp/vendor.dev.js"></script>
   <script>
-    // hot-reload config
-    SystemJS.import('systemjs-hot-reloader').then(function(HotReloader) {
-      // if you're running server on custom port please remember to update below
-      new HotReloader.default('http://localhost:3000');
-    });
-    // load main module of your app with SystemJS
     SystemJS.trace = true;
-    SystemJS.import('src/app');
+    // hot-reload config
+    SystemJS.import('systemjs-hot-reloader').then(function(connect) {
+      // if you're running server on custom port please remember to update below
+      connect({host:'http://localhost:3000'});
+      // load main module of your app with SystemJS
+      SystemJS.import('src/app');
+    });
   </script>
   <!-- loading-app:end -->
 </body>

--- a/jest.config.json
+++ b/jest.config.json
@@ -12,6 +12,8 @@
     "<rootDir>/node_modules/react-addons-test-utils",
     "<rootDir>/node_modules/fbjs"
   ],
+  "moduleNameMapper": {
+  },
   "transform": {
     "^.+\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
   },

--- a/jspm.config.js
+++ b/jspm.config.js
@@ -107,6 +107,7 @@ SystemJS.config({
     "url": "npm:jspm-nodelibs-url@0.2.0",
     "util": "npm:jspm-nodelibs-util@0.2.1",
     "vm": "npm:jspm-nodelibs-vm@0.2.0",
+    "whatwg-fetch": "npm:whatwg-fetch@2.0.3",
     "zlib": "npm:jspm-nodelibs-zlib@0.2.2"
   },
   packages: {

--- a/jspm.config.js
+++ b/jspm.config.js
@@ -10,22 +10,22 @@ SystemJS.config({
   devConfig: {
     "map": {
       "plugin-typescript": "github:frankwallis/plugin-typescript@7.0.5",
-      "css": "github:systemjs/plugin-css@0.1.32",
+      "css": "github:systemjs/plugin-css@0.1.33",
       "systemjs-hot-reloader": "npm:systemjs-hot-reloader@1.1.0",
       "typescript": "npm:typescript@2.2.1"
     },
     "packages": {
       "npm:systemjs-hot-reloader@1.1.0": {
         "map": {
-          "systemjs-hmr": "npm:systemjs-hmr@2.0.8"
+          "systemjs-hmr": "npm:systemjs-hmr@2.0.9"
         }
       },
       "npm:typescript@2.2.1": {
         "map": {
-          "source-map-support": "npm:source-map-support@0.4.11"
+          "source-map-support": "npm:source-map-support@0.4.12"
         }
       },
-      "npm:source-map-support@0.4.11": {
+      "npm:source-map-support@0.4.12": {
         "map": {
           "source-map": "npm:source-map@0.5.6"
         }
@@ -94,7 +94,7 @@ SystemJS.config({
     "react": "npm:react@15.4.2",
     "react-dom": "npm:react-dom@15.4.2",
     "react-redux": "npm:react-redux@5.0.3",
-    "react-redux-typescript": "npm:react-redux-typescript@2.0.0",
+    "react-redux-typescript": "npm:react-redux-typescript@2.1.0",
     "react-router": "npm:react-router@2.8.1",
     "react-router-redux": "npm:react-router-redux@4.0.8",
     "redux": "npm:redux@3.6.0",
@@ -135,7 +135,7 @@ SystemJS.config({
       "map": {
         "create-hash": "npm:create-hash@1.1.2",
         "browserify-rsa": "npm:browserify-rsa@4.0.1",
-        "parse-asn1": "npm:parse-asn1@5.0.0",
+        "parse-asn1": "npm:parse-asn1@5.1.0",
         "bn.js": "npm:bn.js@4.11.6",
         "randombytes": "npm:randombytes@2.0.3"
       }
@@ -168,18 +168,9 @@ SystemJS.config({
         "create-hmac": "npm:create-hmac@1.1.4",
         "browserify-rsa": "npm:browserify-rsa@4.0.1",
         "inherits": "npm:inherits@2.0.3",
-        "parse-asn1": "npm:parse-asn1@5.0.0",
+        "parse-asn1": "npm:parse-asn1@5.1.0",
         "bn.js": "npm:bn.js@4.11.6",
         "elliptic": "npm:elliptic@6.4.0"
-      }
-    },
-    "npm:parse-asn1@5.0.0": {
-      "map": {
-        "create-hash": "npm:create-hash@1.1.2",
-        "evp_bytestokey": "npm:evp_bytestokey@1.0.0",
-        "pbkdf2": "npm:pbkdf2@3.0.9",
-        "browserify-aes": "npm:browserify-aes@1.0.6",
-        "asn1.js": "npm:asn1.js@4.9.1"
       }
     },
     "npm:evp_bytestokey@1.0.0": {
@@ -242,7 +233,7 @@ SystemJS.config({
     "npm:stream-browserify@2.0.1": {
       "map": {
         "inherits": "npm:inherits@2.0.3",
-        "readable-stream": "npm:readable-stream@2.2.3"
+        "readable-stream": "npm:readable-stream@2.2.5"
       }
     },
     "npm:url@0.11.0": {
@@ -253,7 +244,7 @@ SystemJS.config({
     },
     "npm:browserify-zlib@0.1.4": {
       "map": {
-        "readable-stream": "npm:readable-stream@2.2.3",
+        "readable-stream": "npm:readable-stream@2.2.5",
         "pako": "npm:pako@0.2.9"
       }
     },
@@ -401,17 +392,6 @@ SystemJS.config({
         "js-tokens": "npm:js-tokens@3.0.1"
       }
     },
-    "npm:readable-stream@2.2.3": {
-      "map": {
-        "inherits": "npm:inherits@2.0.3",
-        "core-util-is": "npm:core-util-is@1.0.2",
-        "process-nextick-args": "npm:process-nextick-args@1.0.7",
-        "string_decoder": "npm:string_decoder@0.10.31",
-        "buffer-shims": "npm:buffer-shims@1.0.0",
-        "isarray": "npm:isarray@1.0.0",
-        "util-deprecate": "npm:util-deprecate@1.0.2"
-      }
-    },
     "npm:elliptic@6.4.0": {
       "map": {
         "bn.js": "npm:bn.js@4.11.6",
@@ -469,8 +449,28 @@ SystemJS.config({
         "builtin-status-codes": "npm:builtin-status-codes@3.0.0",
         "inherits": "npm:inherits@2.0.3",
         "to-arraybuffer": "npm:to-arraybuffer@1.0.1",
-        "readable-stream": "npm:readable-stream@2.2.3",
+        "readable-stream": "npm:readable-stream@2.2.5",
         "xtend": "npm:xtend@4.0.1"
+      }
+    },
+    "npm:readable-stream@2.2.5": {
+      "map": {
+        "isarray": "npm:isarray@1.0.0",
+        "string_decoder": "npm:string_decoder@0.10.31",
+        "inherits": "npm:inherits@2.0.3",
+        "util-deprecate": "npm:util-deprecate@1.0.2",
+        "core-util-is": "npm:core-util-is@1.0.2",
+        "process-nextick-args": "npm:process-nextick-args@1.0.7",
+        "buffer-shims": "npm:buffer-shims@1.0.0"
+      }
+    },
+    "npm:parse-asn1@5.1.0": {
+      "map": {
+        "browserify-aes": "npm:browserify-aes@1.0.6",
+        "pbkdf2": "npm:pbkdf2@3.0.9",
+        "evp_bytestokey": "npm:evp_bytestokey@1.0.0",
+        "create-hash": "npm:create-hash@1.1.2",
+        "asn1.js": "npm:asn1.js@4.9.1"
       }
     }
   }

--- a/jspm.config.js
+++ b/jspm.config.js
@@ -9,36 +9,25 @@ SystemJS.config({
   },
   devConfig: {
     "map": {
-      "plugin-typescript": "github:frankwallis/plugin-typescript@5.3.3",
+      "plugin-typescript": "github:frankwallis/plugin-typescript@7.0.5",
       "css": "github:systemjs/plugin-css@0.1.32",
-      "systemjs-hot-reloader": "github:capaj/systemjs-hot-reloader@0.6.0"
+      "systemjs-hot-reloader": "npm:systemjs-hot-reloader@1.1.0",
+      "typescript": "npm:typescript@2.2.1"
     },
     "packages": {
-      "github:frankwallis/plugin-typescript@5.3.3": {
+      "npm:systemjs-hot-reloader@1.1.0": {
         "map": {
-          "typescript": "npm:typescript@2.1.4"
+          "systemjs-hmr": "npm:systemjs-hmr@2.0.8"
         }
       },
-      "npm:typescript@2.1.4": {
+      "npm:typescript@2.2.1": {
         "map": {
-          "source-map-support": "npm:source-map-support@0.4.8"
+          "source-map-support": "npm:source-map-support@0.4.11"
         }
       },
-      "npm:source-map-support@0.4.8": {
+      "npm:source-map-support@0.4.11": {
         "map": {
           "source-map": "npm:source-map@0.5.6"
-        }
-      },
-      "github:capaj/systemjs-hot-reloader@0.6.0": {
-        "map": {
-          "debug": "npm:debug@2.6.0",
-          "weakee": "npm:weakee@1.0.0",
-          "socket.io-client": "github:socketio/socket.io-client@1.7.2"
-        }
-      },
-      "npm:debug@2.6.0": {
-        "map": {
-          "ms": "npm:ms@0.7.2"
         }
       }
     }
@@ -90,7 +79,7 @@ SystemJS.config({
     "classnames": "npm:classnames@2.2.5",
     "constants": "npm:jspm-nodelibs-constants@0.2.0",
     "crypto": "npm:jspm-nodelibs-crypto@0.2.0",
-    "csjs": "npm:csjs@1.0.6",
+    "csjs": "npm:csjs@1.1.0",
     "domain": "npm:jspm-nodelibs-domain@0.2.0",
     "events": "npm:jspm-nodelibs-events@0.2.0",
     "fs": "npm:jspm-nodelibs-fs@0.2.0",
@@ -102,19 +91,19 @@ SystemJS.config({
     "os": "npm:jspm-nodelibs-os@0.2.0",
     "path": "npm:jspm-nodelibs-path@0.2.1",
     "process": "npm:jspm-nodelibs-process@0.2.0",
-    "react": "npm:react@15.4.1",
-    "react-dom": "npm:react-dom@15.4.1",
-    "react-redux": "npm:react-redux@5.0.1",
+    "react": "npm:react@15.4.2",
+    "react-dom": "npm:react-dom@15.4.2",
+    "react-redux": "npm:react-redux@5.0.3",
     "react-redux-typescript": "npm:react-redux-typescript@2.0.0",
     "react-router": "npm:react-router@2.8.1",
-    "react-router-redux": "npm:react-router-redux@4.0.7",
+    "react-router-redux": "npm:react-router-redux@4.0.8",
     "redux": "npm:redux@3.6.0",
     "redux-observable": "npm:redux-observable@0.13.0",
     "reselect": "npm:reselect@2.5.4",
     "rxjs": "npm:rxjs@5.2.0",
     "stream": "npm:jspm-nodelibs-stream@0.2.0",
     "string_decoder": "npm:jspm-nodelibs-string_decoder@0.2.0",
-    "tslib": "npm:tslib@1.5.0",
+    "tslib": "npm:tslib@1.6.0",
     "url": "npm:jspm-nodelibs-url@0.2.0",
     "util": "npm:jspm-nodelibs-util@0.2.1",
     "vm": "npm:jspm-nodelibs-vm@0.2.0",
@@ -264,7 +253,7 @@ SystemJS.config({
     },
     "npm:browserify-zlib@0.1.4": {
       "map": {
-        "readable-stream": "npm:readable-stream@2.2.2",
+        "readable-stream": "npm:readable-stream@2.2.3",
         "pako": "npm:pako@0.2.9"
       }
     },
@@ -278,12 +267,12 @@ SystemJS.config({
     },
     "npm:warning@3.0.0": {
       "map": {
-        "loose-envify": "npm:loose-envify@1.3.0"
+        "loose-envify": "npm:loose-envify@1.3.1"
       }
     },
     "npm:warning@2.1.0": {
       "map": {
-        "loose-envify": "npm:loose-envify@1.3.0"
+        "loose-envify": "npm:loose-envify@1.3.1"
       }
     },
     "npm:query-string@3.0.3": {
@@ -294,7 +283,7 @@ SystemJS.config({
     "npm:react-router@2.8.1": {
       "map": {
         "invariant": "npm:invariant@2.2.2",
-        "loose-envify": "npm:loose-envify@1.3.0",
+        "loose-envify": "npm:loose-envify@1.3.1",
         "warning": "npm:warning@3.0.0",
         "hoist-non-react-statics": "npm:hoist-non-react-statics@1.2.0",
         "history": "npm:history@2.1.2"
@@ -322,7 +311,7 @@ SystemJS.config({
     },
     "npm:jspm-nodelibs-http@0.2.0": {
       "map": {
-        "http-browserify": "npm:stream-http@2.5.0"
+        "http-browserify": "npm:stream-http@2.6.3"
       }
     },
     "npm:jspm-nodelibs-url@0.2.0": {
@@ -345,34 +334,9 @@ SystemJS.config({
         "string_decoder-browserify": "npm:string_decoder@0.10.31"
       }
     },
-    "npm:loose-envify@1.3.0": {
-      "map": {
-        "js-tokens": "npm:js-tokens@2.0.0"
-      }
-    },
     "npm:invariant@2.2.2": {
       "map": {
-        "loose-envify": "npm:loose-envify@1.3.0"
-      }
-    },
-    "npm:stream-http@2.5.0": {
-      "map": {
-        "builtin-status-codes": "npm:builtin-status-codes@2.0.0",
-        "inherits": "npm:inherits@2.0.3",
-        "to-arraybuffer": "npm:to-arraybuffer@1.0.1",
-        "readable-stream": "npm:readable-stream@2.2.2",
-        "xtend": "npm:xtend@4.0.1"
-      }
-    },
-    "npm:readable-stream@2.2.2": {
-      "map": {
-        "inherits": "npm:inherits@2.0.3",
-        "string_decoder": "npm:string_decoder@0.10.31",
-        "isarray": "npm:isarray@1.0.0",
-        "buffer-shims": "npm:buffer-shims@1.0.0",
-        "core-util-is": "npm:core-util-is@1.0.2",
-        "process-nextick-args": "npm:process-nextick-args@1.0.7",
-        "util-deprecate": "npm:util-deprecate@1.0.2"
+        "loose-envify": "npm:loose-envify@1.3.1"
       }
     },
     "npm:sha.js@2.4.8": {
@@ -403,40 +367,6 @@ SystemJS.config({
         "loose-envify": "npm:loose-envify@1.3.1",
         "symbol-observable": "npm:symbol-observable@1.0.4",
         "lodash": "npm:lodash@4.17.4"
-      }
-    },
-    "npm:react-redux@5.0.1": {
-      "map": {
-        "lodash-es": "npm:lodash-es@4.17.4",
-        "loose-envify": "npm:loose-envify@1.3.0",
-        "lodash": "npm:lodash@4.17.4",
-        "invariant": "npm:invariant@2.2.2",
-        "hoist-non-react-statics": "npm:hoist-non-react-statics@1.2.0"
-      }
-    },
-    "npm:react@15.4.1": {
-      "map": {
-        "loose-envify": "npm:loose-envify@1.3.0",
-        "object-assign": "npm:object-assign@4.1.0",
-        "fbjs": "npm:fbjs@0.8.8"
-      }
-    },
-    "npm:react-dom@15.4.1": {
-      "map": {
-        "loose-envify": "npm:loose-envify@1.3.0",
-        "object-assign": "npm:object-assign@4.1.0",
-        "fbjs": "npm:fbjs@0.8.8"
-      }
-    },
-    "npm:fbjs@0.8.8": {
-      "map": {
-        "loose-envify": "npm:loose-envify@1.3.0",
-        "object-assign": "npm:object-assign@4.1.0",
-        "promise": "npm:promise@7.1.1",
-        "setimmediate": "npm:setimmediate@1.0.5",
-        "isomorphic-fetch": "npm:isomorphic-fetch@2.2.1",
-        "ua-parser-js": "npm:ua-parser-js@0.7.12",
-        "core-js": "npm:core-js@1.2.7"
       }
     },
     "npm:promise@7.1.1": {
@@ -498,6 +428,49 @@ SystemJS.config({
         "hash.js": "npm:hash.js@1.0.3",
         "minimalistic-assert": "npm:minimalistic-assert@1.0.0",
         "minimalistic-crypto-utils": "npm:minimalistic-crypto-utils@1.0.1"
+      }
+    },
+    "npm:react-redux@5.0.3": {
+      "map": {
+        "hoist-non-react-statics": "npm:hoist-non-react-statics@1.2.0",
+        "invariant": "npm:invariant@2.2.2",
+        "lodash-es": "npm:lodash-es@4.17.4",
+        "loose-envify": "npm:loose-envify@1.3.1",
+        "lodash": "npm:lodash@4.17.4"
+      }
+    },
+    "npm:react-dom@15.4.2": {
+      "map": {
+        "loose-envify": "npm:loose-envify@1.3.1",
+        "object-assign": "npm:object-assign@4.1.1",
+        "fbjs": "npm:fbjs@0.8.9"
+      }
+    },
+    "npm:react@15.4.2": {
+      "map": {
+        "loose-envify": "npm:loose-envify@1.3.1",
+        "object-assign": "npm:object-assign@4.1.1",
+        "fbjs": "npm:fbjs@0.8.9"
+      }
+    },
+    "npm:fbjs@0.8.9": {
+      "map": {
+        "object-assign": "npm:object-assign@4.1.1",
+        "loose-envify": "npm:loose-envify@1.3.1",
+        "promise": "npm:promise@7.1.1",
+        "setimmediate": "npm:setimmediate@1.0.5",
+        "isomorphic-fetch": "npm:isomorphic-fetch@2.2.1",
+        "ua-parser-js": "npm:ua-parser-js@0.7.12",
+        "core-js": "npm:core-js@1.2.7"
+      }
+    },
+    "npm:stream-http@2.6.3": {
+      "map": {
+        "builtin-status-codes": "npm:builtin-status-codes@3.0.0",
+        "inherits": "npm:inherits@2.0.3",
+        "to-arraybuffer": "npm:to-arraybuffer@1.0.1",
+        "readable-stream": "npm:readable-stream@2.2.3",
+        "xtend": "npm:xtend@4.0.1"
       }
     }
   }

--- a/jspm.config.js
+++ b/jspm.config.js
@@ -107,7 +107,6 @@ SystemJS.config({
     "url": "npm:jspm-nodelibs-url@0.2.0",
     "util": "npm:jspm-nodelibs-util@0.2.1",
     "vm": "npm:jspm-nodelibs-vm@0.2.0",
-    "whatwg-fetch": "npm:whatwg-fetch@1.1.1",
     "zlib": "npm:jspm-nodelibs-zlib@0.2.2"
   },
   packages: {
@@ -377,7 +376,7 @@ SystemJS.config({
     "npm:isomorphic-fetch@2.2.1": {
       "map": {
         "node-fetch": "npm:node-fetch@1.6.3",
-        "whatwg-fetch": "npm:whatwg-fetch@1.1.1"
+        "whatwg-fetch": "npm:whatwg-fetch@2.0.3"
       }
     },
     "npm:node-fetch@1.6.3": {

--- a/package.json
+++ b/package.json
@@ -77,14 +77,13 @@
       "react-router-redux": "npm:react-router-redux@^4.0.7",
       "redux-observable": "npm:redux-observable@^0.13.0",
       "reselect": "npm:reselect@^2.5.4",
-      "tslib": "npm:tslib@^1.5.0",
-      "whatwg-fetch": "npm:whatwg-fetch@^1.1.1"
+      "tslib": "npm:tslib@^1.5.0"
     },
     "devDependencies": {
       "css": "github:systemjs/plugin-css@^0.1.32",
       "plugin-typescript": "github:frankwallis/plugin-typescript@^7.0.5",
       "systemjs-hot-reloader": "npm:systemjs-hot-reloader@^1.1.0",
-      "typescript": "npm:typescript@^2.0.0"
+      "typescript": "npm:typescript@^2.2.1"
     },
     "peerDependencies": {
       "assert": "npm:jspm-nodelibs-assert@^0.2.0",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,9 @@
           "process": "@empty"
         }
       },
+      "npm:tslib@1.6.0": {
+        "format": "cjs"
+      },
       "npm:typescript@2.2.1": {
         "browser": {},
         "map": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "server.js",
   "scripts": {
     "clean": "shx rm -rf dist node_modules jspm_packages",
-    "init": "jspm install && npm run build:dev",
+    "init": "jspm install && npm run dev:bundle",
     "dev": "jspm-hmr -FO",
     "dev:bundle": "node scripts/build.js dev",
     "dev:unbundle": "shx rm temp/vendor.dev.js",
@@ -30,7 +30,9 @@
     "precommit": "npm run lint && npm run tsc",
     "prepush": "npm run precommit && npm test",
     "deploy:init": "node scripts/deploy.js init",
-    "deploy": "cd dist && git checkout gh-pages && git add --all && git commit -m \"New Release\" && git push"
+    "deploy": "cd dist && git checkout gh-pages && git add --all && git commit -m \"New Release\" && git push",
+    "jspm:version": "jspm --version",
+    "jspm:update": "jspm update"
   },
   "dependencies": {},
   "devDependencies": {
@@ -45,7 +47,7 @@
     "@types/systemjs": "^0.19.33",
     "husky": "^0.13.0",
     "jest": "^19.0.2",
-    "jspm": "0.17.0-beta.32",
+    "jspm": "0.17.0-beta.40",
     "jspm-hmr": "^1.0.0-rc4",
     "react-redux-typescript": "^2.0.0",
     "redux-observable": "^0.13.0",
@@ -80,8 +82,9 @@
     },
     "devDependencies": {
       "css": "github:systemjs/plugin-css@^0.1.32",
-      "plugin-typescript": "github:frankwallis/plugin-typescript@^5.3.3",
-      "systemjs-hot-reloader": "github:alexisvincent/systemjs-hot-reloader@^0.6.0"
+      "plugin-typescript": "github:frankwallis/plugin-typescript@^7.0.5",
+      "systemjs-hot-reloader": "npm:systemjs-hot-reloader@^1.1.0",
+      "typescript": "npm:typescript@^2.0.0"
     },
     "peerDependencies": {
       "assert": "npm:jspm-nodelibs-assert@^0.2.0",
@@ -99,7 +102,7 @@
       "os": "npm:jspm-nodelibs-os@^0.2.0",
       "path": "npm:jspm-nodelibs-path@^0.2.0",
       "process": "npm:jspm-nodelibs-process@^0.2.0",
-      "react": "npm:react@^15.4.1",
+      "react": "npm:react@^15.4.2",
       "redux": "npm:redux@^3.6.0",
       "rxjs": "npm:rxjs@^5.2.0",
       "stream": "npm:jspm-nodelibs-stream@^0.2.0",
@@ -110,9 +113,6 @@
       "zlib": "npm:jspm-nodelibs-zlib@^0.2.0"
     },
     "overrides": {
-      "github:socketio/socket.io-client@1.7.2": {
-        "main": "dist/socket.io.js"
-      },
       "npm:browserify-zlib@0.1.4": {
         "dependencies": {
           "readable-stream": "^2.0.2",
@@ -120,17 +120,6 @@
         },
         "map": {
           "_stream_transform": "readable-stream/transform"
-        }
-      },
-      "npm:debug@2.6.0": {
-        "main": "src/browser.js",
-        "jspmNodeConversion": false,
-        "format": "cjs",
-        "map": {
-          "fs": "@empty",
-          "net": "@empty",
-          "tty": "@empty",
-          "util": "@empty"
         }
       },
       "npm:inherits@2.0.3": {
@@ -144,11 +133,7 @@
           "process": "@empty"
         }
       },
-      "npm:ms@0.7.2": {
-        "jspmNodeConversion": false,
-        "format": "cjs"
-      },
-      "npm:typescript@2.1.4": {
+      "npm:typescript@2.2.1": {
         "browser": {},
         "map": {
           "buffer": "@empty",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
       "react-router-redux": "npm:react-router-redux@^4.0.7",
       "redux-observable": "npm:redux-observable@^0.13.0",
       "reselect": "npm:reselect@^2.5.4",
-      "tslib": "npm:tslib@^1.5.0"
+      "tslib": "npm:tslib@^1.5.0",
+      "whatwg-fetch": "npm:whatwg-fetch@^2.0.3"
     },
     "devDependencies": {
       "css": "github:systemjs/plugin-css@^0.1.32",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,7 +2,8 @@ require('shelljs/global');
 
 const package = require('../package.json');
 const prodDependencies = Object.keys(package.jspm.dependencies);
-const devDependencies = Object.keys(package.jspm.devDependencies);
+const devDependencies = Object.keys(package.jspm.devDependencies)
+  .filter((package) => package !== "systemjs-hot-reloader");
 const allDependencies = prodDependencies.concat(devDependencies);
 
 const command = process.argv[2];

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,8 +2,7 @@ require('shelljs/global');
 
 const package = require('../package.json');
 const prodDependencies = Object.keys(package.jspm.dependencies);
-const devDependencies = Object.keys(package.jspm.devDependencies)
-  .filter((package) => package !== "systemjs-hot-reloader");
+const devDependencies = Object.keys(package.jspm.devDependencies);
 const allDependencies = prodDependencies.concat(devDependencies);
 
 const command = process.argv[2];

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,6 @@
 // lib imports
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router, Route } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 // const inlineStyles = {};

--- a/src/components/page-hero.tsx
+++ b/src/components/page-hero.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 // const inlineStyles = {};

--- a/src/components/page-section.tsx
+++ b/src/components/page-section.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 // const inlineStyles = {};

--- a/src/containers/css-modules-container/index.tsx
+++ b/src/containers/css-modules-container/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { PageHeader } from '../../components/page-header';
 import { PageSection } from '../../components/page-section';
 

--- a/src/containers/currency-converter-container/components/currency-converter.tsx
+++ b/src/containers/currency-converter-container/components/currency-converter.tsx
@@ -1,5 +1,5 @@
 // lib imports
-import * as React from 'react';
+import React from 'react';
 
 import { CurrencySelect } from './currency-select';
 import { CurrencyInput } from './currency-input';

--- a/src/containers/currency-converter-container/components/currency-input.tsx
+++ b/src/containers/currency-converter-container/components/currency-input.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 interface Props {
   value: string;

--- a/src/containers/currency-converter-container/components/currency-select.tsx
+++ b/src/containers/currency-converter-container/components/currency-select.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 interface Props {
   currencies: string[];

--- a/src/containers/currency-converter-container/index.tsx
+++ b/src/containers/currency-converter-container/index.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-import { returntypeof } from 'react-redux-typescript';
+import RRT from 'react-redux-typescript';
 
 import { RootState } from '../../store';
 import { ActionCreators } from '../../store/currency-converter/reducer';
@@ -21,7 +21,7 @@ const dispatchToProps = {
   changeTargetValue: ActionCreators.ChangeTargetValue.create,
 };
 
-const stateProps = returntypeof(mapStateToProps);
+const stateProps =  RRT.returntypeof(mapStateToProps);
 type Props = typeof stateProps & typeof dispatchToProps;
 type State = {};
 

--- a/src/containers/currency-converter-container/index.tsx
+++ b/src/containers/currency-converter-container/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import RRT from 'react-redux-typescript';
+import { returntypeof } from 'react-redux-typescript';
 
 import { RootState } from '../../store';
 import { ActionCreators } from '../../store/currency-converter/reducer';
@@ -21,7 +21,7 @@ const dispatchToProps = {
   changeTargetValue: ActionCreators.ChangeTargetValue.create,
 };
 
-const stateProps =  RRT.returntypeof(mapStateToProps);
+const stateProps =  returntypeof(mapStateToProps);
 type Props = typeof stateProps & typeof dispatchToProps;
 type State = {};
 

--- a/src/containers/home-container/index.tsx
+++ b/src/containers/home-container/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router';
 import { PageSection } from '../../components/page-section';
 import { PageHero } from '../../components/page-hero';

--- a/src/containers/not-found/index.tsx
+++ b/src/containers/not-found/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router';
 import { PageSection } from '../../components/page-section';
 import { PageHero } from '../../components/page-hero';

--- a/src/layouts/components/layout-footer.tsx
+++ b/src/layouts/components/layout-footer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 const inlineStyles = {

--- a/src/layouts/components/layout-header.tsx
+++ b/src/layouts/components/layout-header.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 // const inlineStyles = {};

--- a/src/layouts/components/layout-main.tsx
+++ b/src/layouts/components/layout-main.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 const inlineStyles = {

--- a/src/layouts/components/layout-top-nav.tsx
+++ b/src/layouts/components/layout-top-nav.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { Link } from 'react-router';
 

--- a/src/layouts/main-layout.tsx
+++ b/src/layouts/main-layout.tsx
@@ -1,5 +1,5 @@
 import './main-layout.css!';
-import * as React from 'react';
+import React from 'react';
 import { LayoutTopNav, LayoutTopNavLink } from './components/layout-top-nav';
 import { LayoutHeader } from './components/layout-header';
 import { LayoutMain } from './components/layout-main';

--- a/src/services/fixer/currency-rates.tsx
+++ b/src/services/fixer/currency-rates.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { validateStatusCode, logRejection } from '../../utils/index';
 
 // Get the latest foreign exchange reference rates in JSON format.

--- a/src/store/currency-rates/reducer.tsx
+++ b/src/store/currency-rates/reducer.tsx
@@ -1,4 +1,4 @@
-import { returntypeof } from 'react-redux-typescript';
+import RRT from 'react-redux-typescript';
 
 import { latestResponse } from '../../services/fixer/fixtures';
 
@@ -22,9 +22,9 @@ export const loadCurrencyRatesError = (payload: string) => ({
 
 // Action Types
 const ActionTypes = {
-  loadCurrencyRates: returntypeof(loadCurrencyRates),
-  loadCurrencyRatesSuccess: returntypeof(loadCurrencyRatesSuccess),
-  loadCurrencyRatesError: returntypeof(loadCurrencyRatesError),
+  loadCurrencyRates: RRT.returntypeof(loadCurrencyRates),
+  loadCurrencyRatesSuccess: RRT.returntypeof(loadCurrencyRatesSuccess),
+  loadCurrencyRatesError: RRT.returntypeof(loadCurrencyRatesError),
 };
 type Action = typeof ActionTypes[keyof typeof ActionTypes];
 

--- a/src/store/currency-rates/reducer.tsx
+++ b/src/store/currency-rates/reducer.tsx
@@ -1,4 +1,4 @@
-import RRT from 'react-redux-typescript';
+import { returntypeof } from 'react-redux-typescript';
 
 import { latestResponse } from '../../services/fixer/fixtures';
 
@@ -22,9 +22,9 @@ export const loadCurrencyRatesError = (payload: string) => ({
 
 // Action Types
 const ActionTypes = {
-  loadCurrencyRates: RRT.returntypeof(loadCurrencyRates),
-  loadCurrencyRatesSuccess: RRT.returntypeof(loadCurrencyRatesSuccess),
-  loadCurrencyRatesError: RRT.returntypeof(loadCurrencyRatesError),
+  loadCurrencyRates: returntypeof(loadCurrencyRates),
+  loadCurrencyRatesSuccess: returntypeof(loadCurrencyRatesSuccess),
+  loadCurrencyRatesError: returntypeof(loadCurrencyRatesError),
 };
 type Action = typeof ActionTypes[keyof typeof ActionTypes];
 

--- a/src/types/example-react-module.d.ts
+++ b/src/types/example-react-module.d.ts
@@ -1,6 +1,6 @@
 // example external React Module declaration
 declare module 'example-react-module' {
-  import * as React from 'react';
+  import React from 'react';
 
   // public components
   interface ReactComponentProps extends React.Props<ReactComponent> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,7 +248,7 @@ babel-code-frame@^6.20.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.18.2, babel-core@^6.23.0, babel-core@^6.9.0:
+babel-core@^6.0.0, babel-core@^6.18.2, babel-core@^6.23.0:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.23.1.tgz#c143cb621bb2f621710c220c5d579d15b8a442df"
   dependencies:
@@ -377,15 +377,16 @@ babel-plugin-syntax-async-generators@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
 
-babel-plugin-transform-cjs-system-require@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-cjs-system-require/-/babel-plugin-transform-cjs-system-require-0.1.1.tgz#ffef26d31bc270e82bdbbd437db2777e85162a29"
-
-babel-plugin-transform-cjs-system-wrapper@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-cjs-system-wrapper/-/babel-plugin-transform-cjs-system-wrapper-0.2.1.tgz#e855078877b56d4d1b92b9f91b37f599db0200e3"
+babel-plugin-transform-amd-system-wrapper@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-amd-system-wrapper/-/babel-plugin-transform-amd-system-wrapper-0.3.3.tgz#468d1560cae578b4dcb8543466f59325f1414f47"
   dependencies:
-    babel-plugin-transform-cjs-system-require "^0.1.1"
+    babel-template "^6.9.0"
+
+babel-plugin-transform-cjs-system-wrapper@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-cjs-system-wrapper/-/babel-plugin-transform-cjs-system-wrapper-0.6.0.tgz#e6eddad07b0412a103fe3667f13a48824ba8fba9"
+  dependencies:
     babel-template "^6.9.0"
 
 babel-plugin-transform-es2015-arrow-functions@^6.8.0:
@@ -432,13 +433,13 @@ babel-plugin-transform-es2015-modules-systemjs@^6.6.5:
     babel-runtime "^6.22.0"
     babel-template "^6.23.0"
 
-babel-plugin-transform-global-system-wrapper@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-global-system-wrapper/-/babel-plugin-transform-global-system-wrapper-0.0.1.tgz#afb469cec0e04689b9fe7e8b1fd280fc94a6d8f2"
+babel-plugin-transform-global-system-wrapper@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-global-system-wrapper/-/babel-plugin-transform-global-system-wrapper-0.3.0.tgz#ddea2a2dc3f802593bdc0d026edb887763a53d6a"
   dependencies:
     babel-template "^6.9.0"
 
-babel-plugin-transform-system-register@0.0.1:
+babel-plugin-transform-system-register@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-system-register/-/babel-plugin-transform-system-register-0.0.1.tgz#9dff40390c2763ac518f0b2ad7c5ea4f65a5be25"
 
@@ -2324,7 +2325,7 @@ jspm-hmr@^1.0.0-rc4:
     shelljs "^0.7.6"
     tslib "^1.5.0"
 
-jspm-npm@^0.30.0:
+jspm-npm@^0.30.2:
   version "0.30.2"
   resolved "https://registry.yarnpkg.com/jspm-npm/-/jspm-npm-0.30.2.tgz#56de14b1315904dcb87b47878a1161b180ef2319"
   dependencies:
@@ -2348,9 +2349,9 @@ jspm-registry@^0.4.1:
     rsvp "^3.0.18"
     semver "^4.3.3"
 
-jspm@0.17.0-beta.32:
-  version "0.17.0-beta.32"
-  resolved "https://registry.yarnpkg.com/jspm/-/jspm-0.17.0-beta.32.tgz#53e8a18b6f4aeb689d3ee3b527e390301a2ae727"
+jspm@0.17.0-beta.40:
+  version "0.17.0-beta.40"
+  resolved "https://registry.yarnpkg.com/jspm/-/jspm-0.17.0-beta.40.tgz#3bca1969b79818e4b9a7a559e797f3613c0ee688"
   dependencies:
     bluebird "^3.0.5"
     chalk "^1.1.1"
@@ -2358,7 +2359,7 @@ jspm@0.17.0-beta.32:
     glob "^6.0.1"
     graceful-fs "^4.1.2"
     jspm-github "^0.14.11"
-    jspm-npm "^0.30.0"
+    jspm-npm "^0.30.2"
     jspm-registry "^0.4.1"
     liftoff "^2.2.0"
     minimatch "^3.0.0"
@@ -2369,8 +2370,8 @@ jspm@0.17.0-beta.32:
     rimraf "^2.4.4"
     sane "^1.3.3"
     semver "^5.1.0"
-    systemjs "0.19.41"
-    systemjs-builder "0.15.34"
+    systemjs "0.20.9"
+    systemjs-builder "0.16.3"
     traceur "0.0.105"
     uglify-js "^2.6.1"
 
@@ -3141,10 +3142,11 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@~2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@~2.1.4:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
   dependencies:
+    buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"
@@ -3152,11 +3154,10 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@~2.1.4:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
+readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@~2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
   dependencies:
-    buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"
@@ -3395,19 +3396,7 @@ rxjs@^5.2.0:
   dependencies:
     symbol-observable "^1.0.1"
 
-sane@^1.3.3:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-1.6.0.tgz#9610c452307a135d29c1fdfe2547034180c46775"
-  dependencies:
-    anymatch "^1.3.0"
-    exec-sh "^0.2.0"
-    fb-watchman "^1.8.0"
-    minimatch "^3.0.2"
-    minimist "^1.1.1"
-    walker "~1.0.5"
-    watch "~0.10.0"
-
-sane@~1.5.0:
+sane@^1.3.3, sane@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.5.0.tgz#a4adeae764d048621ecb27d5f9ecf513101939f3"
   dependencies:
@@ -3699,15 +3688,16 @@ symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-systemjs-builder@0.15.34:
-  version "0.15.34"
-  resolved "https://registry.yarnpkg.com/systemjs-builder/-/systemjs-builder-0.15.34.tgz#6f1b7437e681e395bbdadb2e0b9d4bfd86f1ce56"
+systemjs-builder@0.16.3:
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/systemjs-builder/-/systemjs-builder-0.16.3.tgz#7dc830f816cf2a86d03019d057ca1bd096659c18"
   dependencies:
-    babel-core "^6.9.0"
-    babel-plugin-transform-cjs-system-wrapper "^0.2.1"
+    babel-core "^6.18.2"
+    babel-plugin-transform-amd-system-wrapper "^0.3.3"
+    babel-plugin-transform-cjs-system-wrapper "^0.6.0"
     babel-plugin-transform-es2015-modules-systemjs "^6.6.5"
-    babel-plugin-transform-global-system-wrapper "0.0.1"
-    babel-plugin-transform-system-register "0.0.1"
+    babel-plugin-transform-global-system-wrapper "^0.3.0"
+    babel-plugin-transform-system-register "^0.0.1"
     bluebird "^3.3.4"
     data-uri-to-buffer "0.0.4"
     es6-template-strings "^2.0.0"
@@ -3715,13 +3705,17 @@ systemjs-builder@0.15.34:
     mkdirp "^0.5.1"
     rollup "^0.36.3"
     source-map "^0.5.3"
-    systemjs "^0.19.41"
+    systemjs "^0.19.46"
     traceur "0.0.105"
     uglify-js "^2.6.1"
 
-systemjs@0.19.41, systemjs@^0.19.41:
-  version "0.19.41"
-  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-0.19.41.tgz#835d2c0f10bf403b551fedc875f84bb44a02c4eb"
+systemjs@0.20.9:
+  version "0.20.9"
+  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-0.20.9.tgz#80c00a89511a2064c3f57ce6e8f27784620477ec"
+
+systemjs@^0.19.46:
+  version "0.19.46"
+  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-0.19.46.tgz#c04574b3335f052a0e3c7a00ee4188c6e4c1e38e"
   dependencies:
     when "^3.7.5"
 


### PR DESCRIPTION
I had to update the package on my fork because systemjs-hot-reloader@0.6.0 reloading did not trigger parent dependency updates for plugin-text (i.e. module that imports text file does not update when text file is updated). Updating to v1.1.0 seems to fix this issue.

Here's a PR in case you were planning to update these dependencies.

Updating to systemjs-hot-reloader@ 1.1.0 requires updating jspm/systemjs.
 
New breaking changes in SystemJS@ 0.20.x due to NodeJS ES Module directions http://guybedford.com/systemjs-alignment.
- > That is, import { name } from 'cjs.js', where cjs.js is a CommonJS module will no longer be supported, and instead will require import cjs from 'cjs.js'; cjs.name. `

- Now cjs modules need to be compiled with `__esModules` in order for `import { name } from 'cjs.js'`
  - This requires https://github.com/piotrwitek/react-redux-typescript/pull/2 to be updated to generate `exports.__esModules = true`.
Tried using systemjs configuration via esModule option but it doesn't seem to be working: https://github.com/systemjs/builder/issues/775
- Unit testing seemed to have broke with
  ```
  ReferenceError: System is not defined
      at Object.<anonymous> (src/store/currency-rates/spec/currency-rates-reducer.spec.tsx:1:119)
  ```
  - For some reason adding `moduleNameMapper` seemed to allow Jest to resolve this

Also, side note, Jest doesn't seem to support JSPM/Systemjs correctly :
http://stackoverflow.com/questions/32945193/jest-testing-with-es6-jspm-systemjs-reactjs

