### PR TITLE
Copy assets after dist folder has been created

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -24,10 +24,10 @@ switch (command) {
     break;
 
   case 'app':
-    cp('assets/*', 'dist');
     exec(
       `jspm build src/app - ${prodDependencies.join(' - ')} dist/app.js --skip-source-maps --minify`
     );
+    cp('assets/*', 'dist');
     break;
 
   case 'debug':


### PR DESCRIPTION
The production build script fails when it tries to copy the content of the assets folder to a non-existing folder.