### PR TITLE
Update init script to use the renamed dev:bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "server.js",
   "scripts": {
     "clean": "shx rm -rf dist node_modules jspm_packages",
-    "init": "jspm install && npm run build:dev",
+    "init": "jspm install && npm run dev:bundle",
     "dev": "jspm-hmr -FO",
     "dev:bundle": "node scripts/build.js dev",
     "dev:unbundle": "shx rm temp/vendor.dev.js",


### PR DESCRIPTION
The script "build:dev" used by "init" has been renamed to "dev:bundle".