### PR TITLE
Set base to / to allow navigation straight to nested paths

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -5,6 +5,8 @@
   <meta charset="utf-8">
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <!-- Change the href below if your application is not served from the root -->
+  <base href="/"/>
   <title>React / Redux / TypeScript - starter-kit</title>
   <link rel="stylesheet" href="loader-styles.css">
   <link rel="stylesheet" href="https://unpkg.com/blaze@3.2.0">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <meta charset="utf-8">
   <meta name="description" content>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <!-- Change the href below if your application is not served from the root -->  
+  <base href="/"/>
   <title>React / Redux / TypeScript - starter-kit</title>
   <link href="assets/loader-styles.css" rel="stylesheet">
   <link href="https://unpkg.com/blaze@3.2.0" rel="stylesheet">

--- a/jspm.config.js
+++ b/jspm.config.js
@@ -94,6 +94,7 @@ SystemJS.config({
     "domain": "npm:jspm-nodelibs-domain@0.2.0",
     "events": "npm:jspm-nodelibs-events@0.2.0",
     "fs": "npm:jspm-nodelibs-fs@0.2.0",
+    "history": "npm:history@2.1.2",
     "http": "npm:jspm-nodelibs-http@0.2.0",
     "https": "npm:jspm-nodelibs-https@0.2.1",
     "insert-css": "npm:insert-css@1.1.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,8 +14,9 @@ import CurrencyConverterContainer from './containers/currency-converter-containe
 import { store } from './store/index';
 
 // switch between browser history or hash history
-import { browserHistory } from 'react-router';
-const history = syncHistoryWithStore(browserHistory, store) as any;
+import { useRouterHistory } from 'react-router';
+import { createHistory } from 'history';
+const history = syncHistoryWithStore(useRouterHistory(createHistory)({basename: '/'}), store) as any;
 // import { hashHistory } from 'react-router';
 // const history = syncHistoryWithStore(hashHistory, store) as any;
 


### PR DESCRIPTION
Currently you can't navigate directly to a nested path by typing the url directly in the browser. This fails because the relative paths in the script tags of index.html.

To reproduce:
Launch the project using npm run dev
Navigate directly to http://localhost:3000/a/b

Expected:
The * route is matched and the NotFoundContainer is displayed

Actual:
Page fails to load due to 404 errors from trying to load the scripts in index.html relative from http://localhost:3000/a

This also affects any explicitly defined route which is more than one level deep. If one were to create the route /a/b and try to directly navigate to it the same thing happens.

I'm not sure if there's a better way to solve this, currently you have to update in multiple places if you want to have your application served from a subdirectory rather than the server root.

The change in app.tsx is simply to avoid using deprecated functionality and avoid console warnings. It will work with just the html changes, though display a warning in the console when first loading the application.